### PR TITLE
Ordered-types

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -431,7 +431,9 @@ impl Interface {
             }
         }
 
-        res.into_iter().collect()
+        let mut fin: Vec<String> = res.into_iter().collect();
+        fin.sort();
+        fin
     }
 
     pub fn imports(&self, abi: &Abi) -> Vec<import::Import> {


### PR DESCRIPTION
Ensure the order of FFI-Types is ordered alphabetically by name so that it always creates the same ffi-file
