### PR TITLE
fix: don't deallocate string on read

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-07-29"
 components = [ "rustfmt", "rust-src", "clippy" ]
 profile = "minimal"
 targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu" ]

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -238,11 +238,6 @@ impl DartGenerator {
                 final parts = _api._ffiStringIntoParts(_box.borrow());
                 final ffi.Pointer<ffi.Uint8> tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
                 final tmp1 = utf8.decode(tmp2_0.asTypedList(parts.len));
-                if (parts.capacity > 0) {
-                  final ffi.Pointer<ffi.Void> tmp2_0;
-                  tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
-                  _api.__deallocate(tmp2_0, parts.capacity * 1, 1);
-                }
                 return tmp1;
               }
 


### PR DESCRIPTION
fixes a crash when deallocating a list of strings, that have already deallocated because of the code this removes