### PR TITLE
Change dart symbol limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@a26e6d85971a8fe86d8e574311349dc7f73b3b98
+    - uses: dart-lang/setup-dart@af03c72f0b6abecae6c179017713a4249e1fa011
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@v1
       with:
-        sdk: 2.18.6
+        sdk: 2.15.1
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@af03c72f0b6abecae6c179017713a4249e1fa011
+    - uses: dart-lang/setup-dart@77b84bec90e9a0d07f68a3cedd3651ba9e606a12
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@08de7e0c9a57cb3229b052af11c7f8eae4a845bd
+    - uses: dart-lang/setup-dart@bd8bef0960777f45de11f484bcb7beacadb321cf
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@v1
+    - uses: dart-lang/setup-dart@v1.1
       with:
-        sdk: 2.15.1
+        sdk: 2.19.6
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@77b84bec90e9a0d07f68a3cedd3651ba9e606a12
+    - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
       with:
-        sdk: 2.19.6
+        sdk: 2.16
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
       with:
-        sdk: 2.16
+        sdk: 2.16.2
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+    - uses: dart-lang/setup-dart@v1
       with:
-        sdk: 2.16.1
+        sdk: 2.19.6
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@bd8bef0960777f45de11f484bcb7beacadb321cf
+    - uses: dart-lang/setup-dart@a26e6d85971a8fe86d8e574311349dc7f73b3b98
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@v1.1
+    - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
       with:
-        sdk: 2.16.2
+        sdk: 2.16.1
 
     - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
 
     - uses: dart-lang/setup-dart@v1
       with:
-        sdk: 2.19.6
+        sdk: 2.18.6
 
-    - run: npm i -g prettier 
+    - run: npm i -g prettier
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked
 
     - name: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@7e4ec4f1811e09ce8f339b4d3044220ca799e6c6
+    - uses: dart-lang/setup-dart@08de7e0c9a57cb3229b052af11c7f8eae4a845bd
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         channel: nightly
 
-    - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+    - uses: dart-lang/setup-dart@7e4ec4f1811e09ce8f339b4d3044220ca799e6c6
       with:
         sdk: 2.19.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         channel: nightly
 
     - uses: dart-lang/setup-dart@v1
+      with:
+        sdk: 2.19.6
+
     - run: npm i -g prettier 
     - run: cargo install --git https://github.com/vmx/wasm-multi-value-reverse-polyfill --locked
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ test_runner = ["tempfile", "trybuild"]
 anyhow = "1.0.51"
 genco = "0.15.1"
 heck = "0.4.0"
+once_cell = "1.14.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 tempfile = { version = "3.2.0", optional = true }
@@ -32,4 +33,3 @@ optional = true
 [dev-dependencies]
 ffi-gen = { path = ".", features = ["test_runner"] }
 futures = "0.3.17"
-once_cell = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ optional = true
 [dev-dependencies]
 ffi-gen = { path = ".", features = ["test_runner"] }
 futures = "0.3.17"
+once_cell = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ test_runner = ["tempfile", "trybuild"]
 anyhow = "1.0.51"
 genco = "0.15.1"
 heck = "0.4.0"
-once_cell = "1.14.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 tempfile = { version = "3.2.0", optional = true }
@@ -33,4 +32,3 @@ optional = true
 [dev-dependencies]
 ffi-gen = { path = ".", features = ["test_runner"] }
 futures = "0.3.17"
-once_cell = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ optional = true
 [dev-dependencies]
 ffi-gen = { path = ".", features = ["test_runner"] }
 futures = "0.3.17"
+once_cell = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ pest_derive = "2.1.0"
 tempfile = { version = "3.2.0", optional = true }
 trybuild = { version = "1.0.53", optional = true }
 
+[dependencies.proc-macro2]
+version = "=1.0.55" # fix issue 'Your compiler does not support spans which is required by genco'
+
 [dependencies.wasm-bindgen]
 version = "0.2.78"
 optional = true

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,5 +14,6 @@ anyhow = "1.0.53"
 ffi-gen = { version = "0.1.0", path = ".." }
 ffi-gen-macro = { version = "0.1.0", path = "../macro" }
 futures = "0.3.17"
+once_cell = "1.14.0"
 ureq = "2.4.0"
 paste = "1.0.6"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,6 +14,5 @@ anyhow = "1.0.53"
 ffi-gen = { version = "0.1.0", path = ".." }
 ffi-gen-macro = { version = "0.1.0", path = "../macro" }
 futures = "0.3.17"
-once_cell = "1.14.0"
 ureq = "2.4.0"
 paste = "1.0.6"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-29"
+channel = "nightly-2023-04-10"
 components = [ "rustfmt", "rust-src", "clippy" ]
 profile = "minimal"
 targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu" ]

--- a/src/abi/import.rs
+++ b/src/abi/import.rs
@@ -261,7 +261,7 @@ impl Abi {
                 let var = gen.gen_num(NumType::U8);
                 ffi_rets.push(var.clone());
                 instr.push(Instr::HandleNull(var));
-                self.import_return(symbol, &**ty, out, gen, ffi_rets, instr);
+                self.import_return(symbol, ty, out, gen, ffi_rets, instr);
             }
             AbiType::Result(ty) => {
                 let var = gen.gen_num(NumType::U8);
@@ -270,7 +270,7 @@ impl Abi {
                 let cap = gen.gen_num(self.uptr());
                 ffi_rets.extend_from_slice(&[var.clone(), ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::HandleError(var, ptr, len, cap));
-                self.import_return(symbol, &**ty, out, gen, ffi_rets, instr);
+                self.import_return(symbol, ty, out, gen, ffi_rets, instr);
             }
             AbiType::RefIter(_) => todo!(),
             AbiType::Iter(_) => {

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1049,7 +1049,7 @@ pub mod test_runner {
         let iface = Interface::parse(iface)?;
         let (mut rust_file, rust_file_path) = NamedTempFile::new()?.keep()?;
         writeln!(rust_file, "#![feature(vec_into_raw_parts)]")?;
-        writeln!(rust_file, "#![feature(lazy_cell)]")?;
+        writeln!(rust_file, "#![feature(once_cell)]")?;
         let rust_gen = RustGenerator::new(Abi::native());
         let rust_tokens = rust_gen.generate(iface.clone());
         let (mut dart_file, dart_file_path) = NamedTempFile::new()?.keep()?;

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -54,7 +54,7 @@ impl DartGenerator {
             ffi.Pointer<T> _lookupDartSymbol<T extends ffi.NativeType>(String symbol) {
                 final ffi.Pointer<_DartApi> api = ffi.NativeApi.initializeApiDLData.cast();
                 final ffi.Pointer<_DartApiEntry> functions = api.ref.functions;
-                for (var i = 0; i < 100; i++) {
+                for (var i = 0; i < 10000; i++) {
                     final func = functions.elementAt(i).ref;
                     var symbol2 = "";
                     var j = 0;

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -54,7 +54,7 @@ impl DartGenerator {
             ffi.Pointer<T> _lookupDartSymbol<T extends ffi.NativeType>(String symbol) {
                 final ffi.Pointer<_DartApi> api = ffi.NativeApi.initializeApiDLData.cast();
                 final ffi.Pointer<_DartApiEntry> functions = api.ref.functions;
-               final maxInt = double.maxFinite.toInt();
+                final maxInt = double.maxFinite.toInt();
                 for (var i = 0; i < maxInt; i++) {
                     final func = functions.elementAt(i).ref;
                     var symbol2 = "";

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -54,7 +54,8 @@ impl DartGenerator {
             ffi.Pointer<T> _lookupDartSymbol<T extends ffi.NativeType>(String symbol) {
                 final ffi.Pointer<_DartApi> api = ffi.NativeApi.initializeApiDLData.cast();
                 final ffi.Pointer<_DartApiEntry> functions = api.ref.functions;
-                for (var i = 0; i < 10000; i++) {
+               final maxInt = double.maxFinite.toInt();
+                for (var i = 0; i < maxInt; i++) {
                     final func = functions.elementAt(i).ref;
                     var symbol2 = "";
                     var j = 0;

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -36,12 +36,12 @@ impl DartGenerator {
             import "dart:isolate";
             import "dart:typed_data";
 
-            final class _DartApiEntry extends ffi.Struct {
+            class _DartApiEntry extends ffi.Struct {
                 external ffi.Pointer<ffi.Uint8> name;
                 external ffi.Pointer<ffi.Void> ptr;
             }
 
-            final class _DartApi extends ffi.Struct {
+            class _DartApi extends ffi.Struct {
                 @ffi.Int32()
                 external int major;
 
@@ -247,7 +247,7 @@ impl DartGenerator {
               }
             }
 
-            final class _FfiStringParts extends ffi.Struct {
+            class _FfiStringParts extends ffi.Struct {
               @ffi.Int64()
               external int addr;
               @ffi.Uint64()
@@ -256,7 +256,7 @@ impl DartGenerator {
               external int capacity;
             }
 
-            final class _EnumWrapper extends ffi.Struct {
+            class _EnumWrapper extends ffi.Struct {
                 @ffi.Uint32()
                 external int tag;
                 @ffi.IntPtr()
@@ -928,7 +928,7 @@ impl DartGenerator {
     fn generate_return_struct(&self, ret: &Return) -> dart::Tokens {
         if let Return::Struct(vars, name) = ret {
             quote! {
-                final class #(format!("_{}", self.type_ident(name))) extends ffi.Struct {
+                class #(format!("_{}", self.type_ident(name))) extends ffi.Struct {
                     #(for (i, var) in vars.iter().enumerate() => #(self.generate_return_struct_field(i, var.ty.num())))
                 }
             }

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -928,7 +928,7 @@ impl DartGenerator {
     fn generate_return_struct(&self, ret: &Return) -> dart::Tokens {
         if let Return::Struct(vars, name) = ret {
             quote! {
-                class #(format!("_{}", self.type_ident(name))) extends ffi.Struct {
+                final class #(format!("_{}", self.type_ident(name))) extends ffi.Struct {
                     #(for (i, var) in vars.iter().enumerate() => #(self.generate_return_struct_field(i, var.ty.num())))
                 }
             }

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -36,12 +36,12 @@ impl DartGenerator {
             import "dart:isolate";
             import "dart:typed_data";
 
-            class _DartApiEntry extends ffi.Struct {
+            final class _DartApiEntry extends ffi.Struct {
                 external ffi.Pointer<ffi.Uint8> name;
                 external ffi.Pointer<ffi.Void> ptr;
             }
 
-            class _DartApi extends ffi.Struct {
+            final class _DartApi extends ffi.Struct {
                 @ffi.Int32()
                 external int major;
 
@@ -247,7 +247,7 @@ impl DartGenerator {
               }
             }
 
-            class _FfiStringParts extends ffi.Struct {
+            final class _FfiStringParts extends ffi.Struct {
               @ffi.Int64()
               external int addr;
               @ffi.Uint64()
@@ -256,7 +256,7 @@ impl DartGenerator {
               external int capacity;
             }
 
-            class _EnumWrapper extends ffi.Struct {
+            final class _EnumWrapper extends ffi.Struct {
                 @ffi.Uint32()
                 external int tag;
                 @ffi.IntPtr()

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -645,7 +645,7 @@ impl DartGenerator {
     fn generate_ffi_buffer(&self, ty: &str) -> dart::Tokens {
         let bytes = ty
             .chars()
-            .skip_while(|&c| !c.is_digit(10))
+            .skip_while(|&c| !c.is_ascii_digit())
             .collect::<String>()
             .parse::<u32>()
             .unwrap()
@@ -866,8 +866,8 @@ impl DartGenerator {
             AbiType::RefSlice(ty) | AbiType::Vec(ty) => {
                 quote!(List<#(self.generate_wrapped_num_type(*ty))>)
             }
-            AbiType::Option(ty) => quote!(#(self.generate_type(&**ty))?),
-            AbiType::Result(ty) => self.generate_type(&**ty),
+            AbiType::Option(ty) => quote!(#(self.generate_type(ty))?),
+            AbiType::Result(ty) => self.generate_type(ty),
             AbiType::Tuple(tuple) => match tuple.len() {
                 0 => quote!(void),
                 1 => self.generate_type(&tuple[0]),

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1049,7 +1049,7 @@ pub mod test_runner {
         let iface = Interface::parse(iface)?;
         let (mut rust_file, rust_file_path) = NamedTempFile::new()?.keep()?;
         writeln!(rust_file, "#![feature(vec_into_raw_parts)]")?;
-        writeln!(rust_file, "#![feature(once_cell)]")?;
+        writeln!(rust_file, "#![feature(lazy_cell)]")?;
         let rust_gen = RustGenerator::new(Abi::native());
         let rust_tokens = rust_gen.generate(iface.clone());
         let (mut dart_file, dart_file_path) = NamedTempFile::new()?.keep()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl FfiGen {
     ) -> Result<()> {
         let dart = DartGenerator::new(library.to_string(), cdylib.to_string());
         let dart = dart.generate(self.iface.clone()).to_file_string()?;
-        std::fs::write(path.as_ref(), &dart)?;
+        std::fs::write(path.as_ref(), dart)?;
         let status = Command::new(if cfg!(windows) { "dart.bat" } else { "dart" })
             .arg("format")
             .arg(path.as_ref())
@@ -75,7 +75,7 @@ impl FfiGen {
     pub fn generate_js<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let js = JsGenerator::default();
         let js = js.generate(self.iface.clone()).to_file_string()?;
-        std::fs::write(path.as_ref(), &js)?;
+        std::fs::write(path.as_ref(), js)?;
         let status = Command::new("prettier")
             .arg("--write")
             .arg(path.as_ref())
@@ -91,7 +91,7 @@ impl FfiGen {
     pub fn generate_ts<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let ts = TsGenerator::default();
         let ts = ts.generate(self.iface.clone()).to_file_string()?;
-        std::fs::write(path.as_ref(), &ts)?;
+        std::fs::write(path.as_ref(), ts)?;
         let status = Command::new("prettier")
             .arg("--write")
             .arg(path.as_ref())

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -792,7 +792,7 @@ pub mod test_runner {
         let res = tokens.to_file_string()?;
         let mut tmp = NamedTempFile::new()?;
         writeln!(tmp, "#![feature(vec_into_raw_parts)]")?;
-        writeln!(tmp, "#![feature(once_cell)]")?;
+        writeln!(tmp, "#![feature(lazy_cell)]")?;
         writeln!(tmp, "#![allow(warnings)]")?;
         tmp.write_all(res.as_bytes())?;
         let test = TestCases::new();

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,11 +86,10 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use std::lazy::SyncLazy;
-        use std::sync::Mutex;
+        use std::sync::{LazyLock, Mutex};
 
         const COUNT: usize = 5;
-        static DROP_FLAGS: SyncLazy<Mutex<Vec<bool>>> = SyncLazy::new(|| Mutex::new(vec![false; COUNT]));
+        static DROP_FLAGS: LazyLock<Mutex<Vec<bool>>> = LazyLock::new(|| Mutex::new(vec![false; COUNT]));
 
         #[derive(Debug, Clone)]
         pub struct Obj {

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,7 +86,9 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use std::sync::{Mutex, SyncLazy};
+        use std::sync::Mutex;
+        #![feature(once_cell)]
+        use std::lazy::SyncLazy;
 
         const COUNT: usize = 5;
         static DROP_FLAGS: SyncLazy<Mutex<Vec<bool>>> = SyncLazy::new(|| Mutex::new(vec![false; COUNT]));

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,12 +86,10 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use std::sync::Mutex;
-        #![feature(once_cell)]
-        use std::lazy::SyncLazy;
+        use std::sync::{LazyLock, Mutex};
 
         const COUNT: usize = 5;
-        static DROP_FLAGS: SyncLazy<Mutex<Vec<bool>>> = SyncLazy::new(|| Mutex::new(vec![false; COUNT]));
+        static DROP_FLAGS: LazyLock<Mutex<Vec<bool>>> = LazyLock::new(|| Mutex::new(vec![false; COUNT]));
 
         #[derive(Debug, Clone)]
         pub struct Obj {

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,11 +86,11 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use once_cell::sync::Lazy;
+        use std::lazy::SyncLazy;
         use std::sync::Mutex;
 
         const COUNT: usize = 5;
-        static DROP_FLAGS: Lazy<Mutex<Vec<bool>>> = Lazy::new(|| Mutex::new(vec![false; COUNT]));
+        static DROP_FLAGS: SyncLazy<Mutex<Vec<bool>>> = SyncLazy::new(|| Mutex::new(vec![false; COUNT]));
 
         #[derive(Debug, Clone)]
         pub struct Obj {

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,11 +86,11 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        #![feature(lazy_cell)]
         use std::sync::{LazyLock, Mutex};
 
+        type F = impl FnOnce() -> ();
         const COUNT: usize = 5;
-        static DROP_FLAGS: LazyLock<Mutex<Vec<bool>>> = LazyLock::new(|| Mutex::new(vec![false; COUNT]));
+        static DROP_FLAGS: LazyLock<Mutex<Vec<bool>>, F> = LazyLock::new(|| Mutex::new(vec![false; COUNT]));
 
         #[derive(Debug, Clone)]
         pub struct Obj {

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,6 +86,7 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
+        #![feature(lazy_cell)]
         use std::sync::{LazyLock, Mutex};
 
         const COUNT: usize = 5;

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,8 +86,7 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use std::sync::Mutex;
-        use std::lazy::SyncLazy;
+        use std::sync::{Mutex, SyncLazy};
 
         const COUNT: usize = 5;
         static DROP_FLAGS: SyncLazy<Mutex<Vec<bool>>> = SyncLazy::new(|| Mutex::new(vec![false; COUNT]));

--- a/tests/finalizers.rs
+++ b/tests/finalizers.rs
@@ -86,11 +86,11 @@ compile_pass_no_js! {
     fn has_been_dropped(idx: usize) -> bool;
     ",
     (
-        use std::sync::{LazyLock, Mutex};
+        use once_cell::sync::Lazy;
+        use std::sync::Mutex;
 
-        type F = impl FnOnce() -> ();
         const COUNT: usize = 5;
-        static DROP_FLAGS: LazyLock<Mutex<Vec<bool>>, F> = LazyLock::new(|| Mutex::new(vec![false; COUNT]));
+        static DROP_FLAGS: Lazy<Mutex<Vec<bool>>> = Lazy::new(|| Mutex::new(vec![false; COUNT]));
 
         #[derive(Debug, Clone)]
         pub struct Obj {

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -555,10 +555,7 @@ use std::path::PathBuf;
 
 fn canonical_path(path: String) -> String {
     let dir = PathBuf::from(path.as_str());
-    fs::canonicalize(dir)
-        .unwrap()
-        .to_string_lossy()
-        .to_string()
+    fs::canonicalize(dir).unwrap().to_string_lossy().to_string()
 }
 
 compile_pass_no_js! {

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -555,7 +555,7 @@ use std::path::PathBuf;
 
 fn canonical_path(path: String) -> String {
     let dir = PathBuf::from(path.as_str());
-    fs::canonicalize(&dir)
+    fs::canonicalize(dir)
         .unwrap()
         .to_string_lossy()
         .to_string()

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -550,6 +550,14 @@ compile_pass_no_js! {
     )
 }
 
+use std::fs;
+use std::path::PathBuf;
+
+fn canonical_path(path: String) -> String {
+    let dir = PathBuf::from(path.as_str());
+    fs::canonicalize(&dir).unwrap().to_string_lossy().to_string()
+}
+
 compile_pass_no_js! {
     read_file,
     "
@@ -563,7 +571,7 @@ compile_pass_no_js! {
     ),
     (),
     (
-        final path = "../../../example/dart/image.jpg";
+        final path = #_(#(crate::canonical_path("example/dart/image.jpg".to_string())));
         final img1 = await new File(path).readAsBytes();
         final img2 = await api.readFile(path);
         assert(img1.equals(img2.asTypedList()));

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -555,7 +555,10 @@ use std::path::PathBuf;
 
 fn canonical_path(path: String) -> String {
     let dir = PathBuf::from(path.as_str());
-    fs::canonicalize(&dir).unwrap().to_string_lossy().to_string()
+    fs::canonicalize(&dir)
+        .unwrap()
+        .to_string_lossy()
+        .to_string()
 }
 
 compile_pass_no_js! {


### PR DESCRIPTION
Original limit for `_lookupDartSymbol()` is too small and I will extend that limit.
Because this limit is too small, flutter may not find rust api and app may crash unexpectedly.