### PR TITLE
Make generated ffi portable,  add 32bit support

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -16,6 +16,8 @@ pub enum NumType {
     I64,
     F32,
     F64,
+    IPtr,
+    UPtr,
 }
 
 #[derive(Clone, Debug)]
@@ -46,10 +48,9 @@ pub enum AbiType {
 
 impl AbiType {
     pub fn num(&self) -> NumType {
-        if let Self::Num(num) = self {
-            *num
-        } else {
-            panic!()
+        match self {
+            Self::Num(num) => *num,
+            _ => todo!("{self:?} still missing"),
         }
     }
 }
@@ -219,20 +220,6 @@ impl Abi {
         return Abi::Native64;
     }
 
-    pub(crate) fn uptr(self) -> NumType {
-        match self {
-            Self::Native32 | Self::Wasm32 => NumType::U32,
-            Self::Native64 | Self::Wasm64 => NumType::U64,
-        }
-    }
-
-    pub(crate) fn iptr(self) -> NumType {
-        match self {
-            Self::Native32 | Self::Wasm32 => NumType::I32,
-            Self::Native64 | Self::Wasm64 => NumType::I64,
-        }
-    }
-
     /// Returns the size and alignment of a primitive type.
     pub(crate) fn layout(self, ty: NumType) -> (usize, usize) {
         let size = match ty {
@@ -240,6 +227,8 @@ impl Abi {
             NumType::U16 | NumType::I16 => 2,
             NumType::U32 | NumType::I32 | NumType::F32 => 4,
             NumType::U64 | NumType::I64 | NumType::F64 => 8,
+            NumType::IPtr => todo!(),
+            NumType::UPtr => todo!(),
         };
         let size = match self {
             Self::Native32 | Self::Native64 => size,

--- a/src/abi/export.rs
+++ b/src/abi/export.rs
@@ -34,12 +34,12 @@ impl Abi {
                 instr.push(Instr::LiftNum(arg, out));
             }
             AbiType::Isize => {
-                let arg = gen.gen_num(self.iptr());
+                let arg = gen.gen_num(NumType::IPtr);
                 ffi_args.push(arg.clone());
                 instr.push(Instr::LiftIsize(arg, out));
             }
             AbiType::Usize => {
-                let arg = gen.gen_num(self.uptr());
+                let arg = gen.gen_num(NumType::UPtr);
                 ffi_args.push(arg.clone());
                 instr.push(Instr::LiftUsize(arg, out));
             }
@@ -49,41 +49,41 @@ impl Abi {
                 instr.push(Instr::LiftBool(arg, out));
             }
             AbiType::RefStr => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 ffi_args.extend_from_slice(&[ptr.clone(), len.clone()]);
                 instr.push(Instr::LiftStr(ptr, len, out));
             }
             AbiType::String => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_args.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::LiftString(ptr, len, cap, out));
             }
             AbiType::RefSlice(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 ffi_args.extend_from_slice(&[ptr.clone(), len.clone()]);
                 let ty = *ty;
                 instr.push(Instr::LiftSlice(ptr, len, out, ty));
             }
             AbiType::Vec(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_args.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 let ty = *ty;
                 instr.push(Instr::LiftVec(ptr, len, cap, out, ty));
             }
             AbiType::RefObject(object) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let object = object.clone();
                 instr.push(Instr::LiftRefObject(ptr, out, object));
             }
             AbiType::Object(object) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let object = object.clone();
                 instr.push(Instr::LiftObject(ptr, out, object));
@@ -98,37 +98,37 @@ impl Abi {
             }
             AbiType::Result(_) => todo!(),
             AbiType::RefIter(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftRefIter(ptr, out, ty));
             }
             AbiType::Iter(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftIter(ptr, out, ty));
             }
             AbiType::RefFuture(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftRefFuture(ptr, out, ty));
             }
             AbiType::Future(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftFuture(ptr, out, ty));
             }
             AbiType::RefStream(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftRefStream(ptr, out, ty));
             }
             AbiType::Stream(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LiftStream(ptr, out, ty));
@@ -144,7 +144,7 @@ impl Abi {
             }
             AbiType::Buffer(_) => unimplemented!("\"buffer\" can only be used as return value"),
             AbiType::List(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 instr.push(Instr::LiftRefObject(
                     ptr,
@@ -166,8 +166,8 @@ impl Abi {
             AbiType::Num(num)
                 if matches!((self, num), (Abi::Wasm32, NumType::U64 | NumType::I64)) =>
             {
-                let low = gen.gen_num(self.uptr());
-                let high = gen.gen_num(self.uptr());
+                let low = gen.gen_num(NumType::UPtr);
+                let high = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[low.clone(), high.clone()]);
                 let num_type = *num;
                 instr.push(Instr::LowerNumAsU32Tuple(ret, low, high, num_type));
@@ -178,12 +178,12 @@ impl Abi {
                 instr.push(Instr::LowerNum(ret, out));
             }
             AbiType::Isize => {
-                let out = gen.gen_num(self.iptr());
+                let out = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(out.clone());
                 instr.push(Instr::LowerIsize(ret, out));
             }
             AbiType::Usize => {
-                let out = gen.gen_num(self.uptr());
+                let out = gen.gen_num(NumType::UPtr);
                 ffi_rets.push(out.clone());
                 instr.push(Instr::LowerUsize(ret, out));
             }
@@ -193,40 +193,40 @@ impl Abi {
                 instr.push(Instr::LowerBool(ret, out));
             }
             AbiType::RefStr => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone()]);
                 instr.push(Instr::LowerStr(ret, ptr, len));
             }
             AbiType::String => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::LowerString(ret, ptr, len, cap));
             }
             AbiType::RefSlice(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 let ty = *ty;
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone()]);
                 instr.push(Instr::LowerSlice(ret, ptr, len, ty));
             }
             AbiType::Vec(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 let ty = *ty;
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::LowerVec(ret, ptr, len, cap, ty));
             }
             AbiType::RefObject(_object) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 instr.push(Instr::LowerRefObject(ret, ptr));
             }
             AbiType::Object(_object) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 instr.push(Instr::LowerObject(ret, ptr));
             }
@@ -250,37 +250,37 @@ impl Abi {
                 instr.push(Instr::LowerResult(ret, var, ok, ok_instr, err, err_instr));
             }
             AbiType::RefIter(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerRefIter(ret, ptr, ty));
             }
             AbiType::Iter(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerIter(ret, ptr, ty));
             }
             AbiType::RefFuture(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerRefFuture(ret, ptr, ty));
             }
             AbiType::Future(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerFuture(ret, ptr, ty));
             }
             AbiType::RefStream(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerRefStream(ret, ptr, ty));
             }
             AbiType::Stream(ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let ty = (**ty).clone();
                 instr.push(Instr::LowerStream(ret, ptr, ty));
@@ -297,18 +297,18 @@ impl Abi {
                 instr.extend(instr_inner);
             }
             AbiType::Buffer(_ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 instr.push(Instr::LowerObject(ret, ptr));
             }
             AbiType::List(ty) => {
                 instr.push(Instr::AssertType(ret.clone(), format!("Vec<{}>", ty)));
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 instr.push(Instr::LowerObject(ret, ptr));
             }
             AbiType::RefEnum(_ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 instr.push(Instr::LowerObject(ret.clone(), ptr))
             }
@@ -324,28 +324,28 @@ impl Abi {
         let self_ = match &func.ty {
             FunctionType::Method(object) => {
                 let out = gen.gen(AbiType::RefObject(object.clone()));
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 instr.push(Instr::LiftRefObject(ptr, out.clone(), object.clone()));
                 Some(out)
             }
             FunctionType::NextIter(_, ty) => {
                 let out = gen.gen(AbiType::RefIter(Box::new(ty.clone())));
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 instr.push(Instr::LiftRefIter(ptr, out.clone(), ty.clone()));
                 Some(out)
             }
             FunctionType::PollFuture(_, ty) => {
                 let out = gen.gen(AbiType::RefFuture(Box::new(ty.clone())));
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 instr.push(Instr::LiftRefFuture(ptr, out.clone(), ty.clone()));
                 Some(out)
             }
             FunctionType::PollStream(_, ty) => {
                 let out = gen.gen(AbiType::RefStream(Box::new(ty.clone())));
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_args.push(ptr.clone());
                 instr.push(Instr::LiftRefStream(ptr, out.clone(), ty.clone()));
                 Some(out)

--- a/src/abi/import.rs
+++ b/src/abi/import.rs
@@ -26,8 +26,8 @@ impl Abi {
             AbiType::Num(num)
                 if matches!((self, num), (Abi::Wasm32, NumType::U64 | NumType::I64)) =>
             {
-                let low = gen.gen_num(self.iptr());
-                let high = gen.gen_num(self.iptr());
+                let low = gen.gen_num(NumType::IPtr);
+                let high = gen.gen_num(NumType::IPtr);
 
                 let num_type = *num;
                 instr.push(Instr::LowerNumFromU32Tuple(
@@ -42,17 +42,17 @@ impl Abi {
             }
             AbiType::Num(num) => {
                 let out = gen.gen_num(*num);
-                instr.push(Instr::LowerNum(arg.clone(), out.clone(), *num));
+                instr.push(Instr::LowerNum(arg.clone(), out.clone()));
                 ffi_args.push(out);
             }
             AbiType::Isize => {
-                let out = gen.gen_num(self.iptr());
-                instr.push(Instr::LowerNum(arg, out.clone(), self.iptr()));
+                let out = gen.gen_num(NumType::IPtr);
+                instr.push(Instr::LowerNum(arg, out.clone()));
                 ffi_args.push(out);
             }
             AbiType::Usize => {
-                let out = gen.gen_num(self.uptr());
-                instr.push(Instr::LowerNum(arg, out.clone(), self.uptr()));
+                let out = gen.gen_num(NumType::UPtr);
+                instr.push(Instr::LowerNum(arg, out.clone()));
                 ffi_args.push(out);
             }
             AbiType::Bool => {
@@ -61,9 +61,9 @@ impl Abi {
                 ffi_args.push(out);
             }
             AbiType::RefStr => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 instr.push(Instr::DefineArgs(vec![cap.clone()]));
                 instr.push(Instr::LowerString(
                     arg.clone(),
@@ -77,9 +77,9 @@ impl Abi {
                 instr_cleanup.push(Instr::Deallocate(ptr, cap, 1, 1));
             }
             AbiType::String => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 instr.push(Instr::LowerString(
                     arg.clone(),
                     ptr.clone(),
@@ -91,9 +91,9 @@ impl Abi {
                 ffi_args.extend_from_slice(&[ptr, len, cap]);
             }
             AbiType::RefSlice(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 let (size, align) = self.layout(*ty);
                 instr.push(Instr::DefineArgs(vec![cap.clone()]));
                 instr.push(Instr::LowerVec(
@@ -109,9 +109,9 @@ impl Abi {
                 instr_cleanup.push(Instr::Deallocate(ptr, cap, size, align));
             }
             AbiType::Vec(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 let (size, align) = self.layout(*ty);
                 instr.push(Instr::LowerVec(
                     arg.clone(),
@@ -125,42 +125,42 @@ impl Abi {
                 ffi_args.extend_from_slice(&[ptr, len, cap]);
             }
             AbiType::RefObject(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::BorrowObject(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::Object(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::MoveObject(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::RefIter(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::BorrowIter(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::Iter(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::MoveIter(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::RefFuture(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::BorrowFuture(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::Future(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::MoveFuture(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::RefStream(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::BorrowStream(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
             AbiType::Stream(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::MoveStream(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
@@ -176,7 +176,7 @@ impl Abi {
             AbiType::Result(_) => todo!(),
             AbiType::Buffer(_) => unimplemented!("\"buffer\" can only be used as return value"),
             AbiType::List(_ty) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::MoveObject(arg.clone(), ptr.clone()));
                 ffi_args.push(ptr);
             }
@@ -207,14 +207,14 @@ impl Abi {
                 instr.push(Instr::LiftNum(var, out, *num));
             }
             AbiType::Isize => {
-                let var = gen.gen_num(self.iptr());
+                let var = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(var.clone());
-                instr.push(Instr::LiftNum(var, out, self.iptr()));
+                instr.push(Instr::LiftNum(var, out, NumType::IPtr));
             }
             AbiType::Usize => {
-                let var = gen.gen_num(self.uptr());
+                let var = gen.gen_num(NumType::UPtr);
                 ffi_rets.push(var.clone());
-                instr.push(Instr::LiftNum(var, out, self.uptr()));
+                instr.push(Instr::LiftNum(var, out, NumType::UPtr));
             }
             AbiType::Bool => {
                 let var = gen.gen_num(NumType::U8);
@@ -222,29 +222,29 @@ impl Abi {
                 instr.push(Instr::LiftBool(var, out));
             }
             AbiType::RefStr => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone()]);
                 instr.push(Instr::LiftString(ptr, len, out));
             }
             AbiType::String => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::LiftString(ptr.clone(), len, out));
                 instr.push(Instr::Deallocate(ptr, cap, 1, 1));
             }
             AbiType::RefSlice(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone()]);
                 instr.push(Instr::LiftVec(ptr, len, out, *ty));
             }
             AbiType::Vec(ty) => {
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[ptr.clone(), len.clone(), cap.clone()]);
                 let (size, align) = self.layout(*ty);
                 instr.push(Instr::LiftVec(ptr.clone(), len, out, *ty));
@@ -252,7 +252,7 @@ impl Abi {
             }
             AbiType::RefObject(_) => todo!(),
             AbiType::Object(obj) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let destructor = format!("drop_box_{}", obj);
                 instr.push(Instr::LiftObject(obj.clone(), ptr, destructor, out));
@@ -265,16 +265,16 @@ impl Abi {
             }
             AbiType::Result(ty) => {
                 let var = gen.gen_num(NumType::U8);
-                let ptr = gen.gen_num(self.iptr());
-                let len = gen.gen_num(self.uptr());
-                let cap = gen.gen_num(self.uptr());
+                let ptr = gen.gen_num(NumType::IPtr);
+                let len = gen.gen_num(NumType::UPtr);
+                let cap = gen.gen_num(NumType::UPtr);
                 ffi_rets.extend_from_slice(&[var.clone(), ptr.clone(), len.clone(), cap.clone()]);
                 instr.push(Instr::HandleError(var, ptr, len, cap));
                 self.import_return(symbol, ty, out, gen, ffi_rets, instr);
             }
             AbiType::RefIter(_) => todo!(),
             AbiType::Iter(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let next = format!("{}_iter_next", symbol);
                 let destructor = format!("{}_iter_drop", symbol);
@@ -282,7 +282,7 @@ impl Abi {
             }
             AbiType::RefFuture(_) => todo!(),
             AbiType::Future(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let poll = format!("{}_future_poll", symbol);
                 let destructor = format!("{}_future_drop", symbol);
@@ -290,7 +290,7 @@ impl Abi {
             }
             AbiType::RefStream(_) => todo!(),
             AbiType::Stream(_) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let poll = format!("{}_stream_poll", symbol);
                 let destructor = format!("{}_stream_drop", symbol);
@@ -306,31 +306,31 @@ impl Abi {
                 instr.push(Instr::LiftTuple(vars, out));
             }
             AbiType::Buffer(ty) => {
-                let buf_ptr = gen.gen_num(self.iptr());
+                let buf_ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(buf_ptr.clone());
-                let ffi_buf = gen.gen_num(self.iptr());
+                let ffi_buf = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::LiftObject(
                     ffi_buffer_name_for(*ty).to_string(),
                     buf_ptr,
                     "drop_box_FfiBuffer".to_string(),
                     ffi_buf.clone(),
                 ));
-                instr.push(Instr::LiftNum(ffi_buf, out, self.iptr()));
+                instr.push(Instr::LiftNum(ffi_buf, out, NumType::IPtr));
             }
             AbiType::List(ty) => {
-                let buf_ptr = gen.gen_num(self.iptr());
+                let buf_ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(buf_ptr.clone());
-                let ffi_buf = gen.gen_num(self.iptr());
+                let ffi_buf = gen.gen_num(NumType::IPtr);
                 instr.push(Instr::LiftObject(
                     format!("FfiList{}", ty),
                     buf_ptr,
                     format!("drop_box_FfiList{}", ty),
                     ffi_buf.clone(),
                 ));
-                instr.push(Instr::LiftNum(ffi_buf, out, self.iptr()));
+                instr.push(Instr::LiftNum(ffi_buf, out, NumType::IPtr));
             }
             AbiType::RefEnum(obj) => {
-                let ptr = gen.gen_num(self.iptr());
+                let ptr = gen.gen_num(NumType::IPtr);
                 ffi_rets.push(ptr.clone());
                 let destructor = format!("drop_box_{}", obj);
                 instr.push(Instr::LiftObject(obj.clone(), ptr, destructor, out));
@@ -349,7 +349,7 @@ impl Abi {
         let mut instr_arg = vec![];
         match &func.ty {
             FunctionType::Method(_) => {
-                let self_ = gen.gen_num(self.iptr());
+                let self_ = gen.gen_num(NumType::IPtr);
                 instr_arg.push(Instr::BorrowSelf(self_.clone()));
                 ffi_args.push(self_);
             }
@@ -434,7 +434,7 @@ pub enum Instr {
     BindArg(String, Var),
     Deallocate(Var, Var, usize, usize),
     LiftNum(Var, Var, NumType),
-    LowerNum(Var, Var, NumType),
+    LowerNum(Var, Var),
     LowerNumFromU32Tuple(Var, Var, Var, NumType),
     LiftNumFromU32Tuple(Var, Var, Var, NumType),
     LiftBool(Var, Var),

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -260,11 +260,11 @@ impl DartGenerator {
             }
 
             class _FfiStringParts extends ffi.Struct {
-                @ffi.Int64()
+                @ffi.IntPtr()
                 external int addr;
-                @ffi.Uint64()
+                @ffi.UintPtr()
                 external int len;
-                @ffi.Uint64()
+                @ffi.UintPtr()
                 external int capacity;
             }
 
@@ -365,14 +365,14 @@ impl DartGenerator {
 
                 late final _ffiBufferAddressPtr = _lookup<
                     ffi.NativeFunction<
-                        ffi.IntPtr Function(ffi.IntPtr)>>("__ffi_buffer_address");
+                        ffi.UintPtr Function(ffi.IntPtr)>>("__ffi_buffer_address");
 
                 late final _ffiBufferAddress = _ffiBufferAddressPtr.asFunction<
                     int Function(int)>();
 
                 late final _ffiBufferSizePtr = _lookup<
                     ffi.NativeFunction<
-                        ffi.Uint64 Function(ffi.IntPtr)>>("__ffi_buffer_size");
+                        ffi.UintPtr Function(ffi.IntPtr)>>("__ffi_buffer_size");
 
                 late final _ffiBufferSize = _ffiBufferSizePtr.asFunction<
                     int Function(int)>();
@@ -722,7 +722,7 @@ impl DartGenerator {
                         final $(self.var(var)) = $(self.var(ret)).$(format!("arg{}", idx));)
                 },
             },
-            Instr::LowerNum(in_, out, _num) => {
+            Instr::LowerNum(in_, out) => {
                 quote!($(self.var(out)) = $(self.var(in_));)
             }
             Instr::LiftNum(in_, out, _num) => {
@@ -931,6 +931,8 @@ impl DartGenerator {
             NumType::U64 => quote!(ffi.Uint64),
             NumType::F32 => quote!(ffi.Float),
             NumType::F64 => quote!(ffi.Double),
+            NumType::IPtr => quote!(ffi.IntPtr),
+            NumType::UPtr => quote!(ffi.UintPtr),
         }
     }
 
@@ -1189,5 +1191,7 @@ pub fn ffi_buffer_name_for(ty: NumType) -> &'static str {
         NumType::I64 => "FfiBufferInt64",
         NumType::F32 => "FfiBufferFloat32",
         NumType::F64 => "FfiBufferFloat64",
+        NumType::IPtr => todo!(),
+        NumType::UPtr => todo!(),
     }
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -188,6 +188,8 @@ impl TsGenerator {
                     | NumType::F32
                     | NumType::F64 => quote!(number),
                     NumType::U64 | NumType::I64 => quote!(BigInt),
+                    NumType::IPtr => todo!(),
+                    NumType::UPtr => todo!(),
                 },
                 AbiType::Isize | AbiType::Usize => quote!(number),
                 AbiType::Bool => quote!(boolean),
@@ -594,7 +596,7 @@ impl JsGenerator {
                     $(self.var(out_high)) = $(self.var(out_low))_1[1];
                 }
             }
-            Instr::LowerNum(in_, out, _num) => {
+            Instr::LowerNum(in_, out) => {
                 quote!($(self.var(out)) = $(self.var(in_));)
             }
             Instr::LiftNum(in_, out, _num) => {
@@ -728,6 +730,8 @@ impl JsGenerator {
             NumType::I64 => quote!(BigInt64Array),
             NumType::F32 => quote!(Float32Array),
             NumType::F64 => quote!(Float64Array),
+            NumType::IPtr => todo!(),
+            NumType::UPtr => todo!(),
         }
     }
 


### PR DESCRIPTION
This replaces several instance where we were using `u64` or `i64` as hard-coded instances for `isize` and `usize` with its dart counterparts of `UintPtr` and `IntPtr`. Thus rendering the generated dart file not only platform-compatible with the underlying target system, but also allowing us to the same generated dart file across any number of platforms. Prior to this for the few cases this was using usize-types, the generator would create a platform-specific mapping.

As a result, we do now support 32bit targets as well.